### PR TITLE
Refactor PowerShell Core version requirement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ level agreements guaranteed by the hosted applications in the future.
 
 ### Prerequisites
 
-- Windows PowerShell 5+ / PowerShell Core 7+
+- PowerShell Core 7+
 - Azure CLI
 - "account" extension installed on Azure CLI: `az extension add --name account`
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the prerequisites section, specifying that only PowerShell Core 7+ is required, removing the previous requirement for Windows PowerShell 5+.