### PR TITLE
Refactor AKSCluster.ps1 to support cilium network policy

### DIFF
--- a/AKSCluster.ps1
+++ b/AKSCluster.ps1
@@ -113,7 +113,7 @@ class AKSCluster {
 
     # Checks if the cluster has network policies enabled
     [bool] hasNetworkPoliciesEnabled() {
-        return $this.ClusterObject.networkProfile.networkPolicy -eq "azure" -or $this.ClusterObject.networkProfile.networkPolicy -eq "calico"
+        return $this.ClusterObject.networkProfile.networkPolicy -eq "azure" -or $this.ClusterObject.networkProfile.networkPolicy -eq "calico" -or $this.ClusterObject.networkProfile.networkPolicy -eq "cilium" 
     }
 
     # Checks if the cluster has network plugin mode set cni overlay


### PR DESCRIPTION
This pull request includes a modification to the `hasNetworkPoliciesEnabled` method in the `AKSCluster` class in the `AKSCluster.ps1` file. The change expands the network policy check to include "cilium" in addition to "azure" and "calico". This means that the method will now return true if the `networkPolicy` of the `ClusterObject`'s `networkProfile` is either "azure", "calico", or "cilium".