### PR TITLE
feat: Enable backup extension check in AKS cluster assessment

### DIFF
--- a/AKS/AKSClusterCheck.psm1
+++ b/AKS/AKSClusterCheck.psm1
@@ -220,6 +220,16 @@ class AKSClusterCheck: ResourceCheck {
         return $this.ClusterObject.networkProfile.loadBalancerSku -eq "Standard"
     }
 
+    [bool] hasBackupExtensionEnabled() {
+        $extensions = az k8s-extension list --cluster-type managedClusters --cluster-name $this.ClusterObject.name --resource-group $this.ClusterObject.resourceGroup -o json | ConvertFrom-Json
+        foreach ($extension in $extensions) {
+            if ($extension.name -eq "azure-aks-backup") {
+                return $true
+            }
+        }
+        return $false
+    }
+
 
     [string] toString() {
         return ""

--- a/AKS/aksRules.json
+++ b/AKS/aksRules.json
@@ -14,6 +14,11 @@
     "explanation": "User node pools should be used in the cluster. For more information, see https://learn.microsoft.com/en-us/azure/aks/use-multiple-node-pools",
     "function": "hasUserNodePools"
   },
+  "AKS_Resiliency_Backup": {
+    "expected": true,
+    "explanation": "Backups should be enabled in the cluster. For more information, see https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-cluster-manage-backups",
+    "function": "hasBackupExtensionEnabled"
+  },
 
   "AKS_Private_Cluster": {
     "expected": true,


### PR DESCRIPTION
This pull request primarily focuses on enhancing the resiliency of the Azure Kubernetes Service (AKS) cluster by introducing a backup feature. The two main changes are the addition of a new method in the `AKSClusterCheck` class and the inclusion of a new rule in the `aksRules.json` file.

Resiliency enhancements:

* [`AKS/AKSClusterCheck.psm1`](diffhunk://#diff-11469093a0afc57c0a367daa3bfeb77ae3ae4982af501331c6fb5eeb5d43048aR223-R232): Added a new method `hasBackupExtensionEnabled` in the `AKSClusterCheck` class. This method checks whether the "azure-aks-backup" extension is enabled for the AKS cluster.
* [`AKS/aksRules.json`](diffhunk://#diff-86a081506d25c7f1c898738b3f5323f4fc6e97baeeb9f04fc4da0dbe70dce513R17-R21): Included a new rule "AKS_Resiliency_Backup" which expects the backup extension to be enabled in the AKS cluster. The function `hasBackupExtensionEnabled` is used to validate this rule.

Closes #16 