### PR TITLE
Improved AKS monitoring check

### DIFF
--- a/AKS/AKSClusterCheck.psm1
+++ b/AKS/AKSClusterCheck.psm1
@@ -126,7 +126,9 @@ class AKSClusterCheck: ResourceCheck {
 
     # Checks if Container Insights is enabled
     [bool] isContainerInsightsEnabled() {
-        return  $this.ClusterObject.addonProfiles.omsAgent.enabled
+        $azureMonitorProfile = $null -ne $this.ClusterObject.azureMonitorProfile -and $null -ne $this.ClusterObject.azureMonitorProfile.containerInsights -and $this.ClusterObject.azureMonitorProfile.containerInsights.enabled
+        $addonProfile = $null -ne $this.ClusterObject.addonProfiles -and $null -ne $this.ClusterObject.addonProfiles.omsagent -and $this.ClusterObject.addonProfiles.omsagent.enabled
+        return $azureMonitorProfile -and $addonProfile
     }
 
     # Checks if Azure Policies are enabled
@@ -221,7 +223,7 @@ class AKSClusterCheck: ResourceCheck {
     }
 
     [bool] hasBackupExtensionEnabled() {
-        $extensions = az k8s-extension list --cluster-type managedClusters --cluster-name $this.ClusterObject.name --resource-group $this.ClusterObject.resourceGroup -o json | ConvertFrom-Json
+        $extensions = az k8s-extension list --cluster-type managedClusters --cluster-name $this.getClusterName() --resource-group $this.getClusterResourceGroup() -o json | ConvertFrom-Json
         foreach ($extension in $extensions) {
             if ($extension.name -eq "azure-aks-backup") {
                 return $true


### PR DESCRIPTION
This pull request includes changes to the `AKSClusterCheck` class in the `AKS/AKSClusterCheck.psm1` file to improve the checks for enabled features in Azure Kubernetes Service (AKS) clusters. The changes include modifying the `isContainerInsightsEnabled` method to check both the `azureMonitorProfile` and `addonProfiles` properties, and updating the `hasBackupExtensionEnabled` method to use getter methods for the cluster name and resource group. 

* [`AKS/AKSClusterCheck.psm1`](diffhunk://#diff-11469093a0afc57c0a367daa3bfeb77ae3ae4982af501331c6fb5eeb5d43048aL129-R131): In the `isContainerInsightsEnabled` method, the check for Container Insights enabled status now includes both the `azureMonitorProfile` and `addonProfiles` properties of the `ClusterObject`. This ensures that Container Insights is checked in both places if it's enabled.
* [`AKS/AKSClusterCheck.psm1`](diffhunk://#diff-11469093a0afc57c0a367daa3bfeb77ae3ae4982af501331c6fb5eeb5d43048aL224-R226): In the `hasBackupExtensionEnabled` method, the `az k8s-extension list` command now uses the `getClusterName` and `getClusterResourceGroup` methods to retrieve the cluster name and resource group. This makes the code more maintainable and less prone to errors.

Closes #15 