### PR TITLE
feat: Add AKS cluster running and provisioned checks

### DIFF
--- a/AKS/aksRules.json
+++ b/AKS/aksRules.json
@@ -1,12 +1,12 @@
 {
   "AKS_Running": {
     "expected": true,
-    "explanation": "The cluster should be running.",
+    "explanation": "The cluster should be running to get accurate results. Some results might be wrong due to the current state.",
     "function": "isClusterRunning"
   },
   "AKS_Provisioned": {
     "expected": true,
-    "explanation": "The cluster should be provisioned.",
+    "explanation": "The cluster should be provisioned to get accurate results. Some results might be wrong due to the current state.",
     "function": "isClusterProvisioned"
   },
   "AKS_Resiliency_Autoscaling": {

--- a/AKS/aksRules.json
+++ b/AKS/aksRules.json
@@ -1,4 +1,14 @@
 {
+  "AKS_Running": {
+    "expected": true,
+    "explanation": "The cluster should be running.",
+    "function": "isClusterRunning"
+  },
+  "AKS_Provisioned": {
+    "expected": true,
+    "explanation": "The cluster should be provisioned.",
+    "function": "isClusterProvisioned"
+  },
   "AKS_Resiliency_Autoscaling": {
     "expected": 0,
     "explanation": "Autoscaling should be enabled in the cluster for all nodepools. For more information, see https://learn.microsoft.com/en-us/azure/aks/cluster-autoscaler",


### PR DESCRIPTION
The code changes include adding two new checks for AKS clusters: "AKS_Running" and "AKS_Provisioned". These checks verify if the cluster is running and provisioned, respectively. This enhancement improves the AKS cluster assessment functionality.

Closes #22 