### PR TITLE
feat: Add function to check if AKS cluster has at least 3 nodepools

### DIFF
--- a/AKS/AKSClusterCheck.psm1
+++ b/AKS/AKSClusterCheck.psm1
@@ -41,7 +41,7 @@ class AKSClusterCheck: ResourceCheck {
         return $totalNodeCount
     }
 
-    [bool] IsPoolMin3Nodes() {
+    [bool] hasMin3NodesPerPool() {
         foreach ($nodePool in $this.ClusterObject.agentPoolProfiles) {
             if ($nodePool.minCount -lt 3) {
                 return $false
@@ -50,8 +50,6 @@ class AKSClusterCheck: ResourceCheck {
         return $true
     }
     
-    #create new function that goes through nodepools and checks the minimum if it has atleast 3 nodes. Range od min-max if min is 1 thats not good. If 1 nodepool has min<3 the entire test fails
-
     [bool] isClusterProvisioned() {
         return $this.ClusterObject.provisioningState -eq "Succeeded"
     }

--- a/AKS/AKSClusterCheck.psm1
+++ b/AKS/AKSClusterCheck.psm1
@@ -41,6 +41,17 @@ class AKSClusterCheck: ResourceCheck {
         return $totalNodeCount
     }
 
+    [bool] IsPoolMin3Nodes() {
+        foreach ($nodePool in $this.ClusterObject.agentPoolProfiles) {
+            if ($nodePool.minCount -lt 3) {
+                return $false
+            }
+        }
+        return $true
+    }
+    
+    #create new function that goes through nodepools and checks the minimum if it has atleast 3 nodes. Range od min-max if min is 1 thats not good. If 1 nodepool has min<3 the entire test fails
+
     [bool] isClusterProvisioned() {
         return $this.ClusterObject.provisioningState -eq "Succeeded"
     }

--- a/AKS/aksRules.json
+++ b/AKS/aksRules.json
@@ -1,8 +1,8 @@
 {
-  "AKS_AmountOfNodesinPools": {
+  "AKS_Resiliency_MinNodesPerPool": {
     "expected": true,
     "explanation": "The cluster should have at least 3 nodepools for high availability.",
-    "function": "IsPoolMin3Nodes"
+    "function": "hasMin3NodesPerPool"
   },
   "AKS_Running": {
     "expected": true,

--- a/AKS/aksRules.json
+++ b/AKS/aksRules.json
@@ -31,10 +31,10 @@
   },
   "AKS_Resiliency_MinNodesPerPool": {
     "expected": true,
-    "explanation": "The cluster should have at least 3 nodepools for high availability.",
+    "explanation": "Each nodepool should have at least 3 nodes for high availability.",
     "function": "hasMin3NodesPerPool"
   },
-  
+
   "AKS_Private_Cluster": {
     "expected": true,
     "explanation": "The cluster should be private. For more information, see https://learn.microsoft.com/en-us/azure/aks/private-clusters",

--- a/AKS/aksRules.json
+++ b/AKS/aksRules.json
@@ -1,9 +1,4 @@
 {
-  "AKS_Resiliency_MinNodesPerPool": {
-    "expected": true,
-    "explanation": "The cluster should have at least 3 nodepools for high availability.",
-    "function": "hasMin3NodesPerPool"
-  },
   "AKS_Running": {
     "expected": true,
     "explanation": "The cluster should be running to get accurate results. Some results might be wrong due to the current state.",
@@ -34,7 +29,12 @@
     "explanation": "Backups should be enabled in the cluster. For more information, see https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-cluster-manage-backups",
     "function": "hasBackupExtensionEnabled"
   },
-
+  "AKS_Resiliency_MinNodesPerPool": {
+    "expected": true,
+    "explanation": "The cluster should have at least 3 nodepools for high availability.",
+    "function": "hasMin3NodesPerPool"
+  },
+  
   "AKS_Private_Cluster": {
     "expected": true,
     "explanation": "The cluster should be private. For more information, see https://learn.microsoft.com/en-us/azure/aks/private-clusters",

--- a/AKS/aksRules.json
+++ b/AKS/aksRules.json
@@ -1,4 +1,9 @@
 {
+  "AKS_AmountOfNodesinPools": {
+    "expected": true,
+    "explanation": "The cluster should have at least 3 nodepools for high availability.",
+    "function": "IsPoolMin3Nodes"
+  },
   "AKS_Running": {
     "expected": true,
     "explanation": "The cluster should be running to get accurate results. Some results might be wrong due to the current state.",


### PR DESCRIPTION
The code changes introduce a new function, `IsPoolMin3Nodes()`, which checks if an AKS cluster has at least 3 nodepools for high availability. This function is added to the `AKSClusterCheck` class and enhances the AKS cluster assessment functionality.

Closes #24  
(teams message, I drafted cz am not sure)
