### PR TITLE
Aks/nodepoolcheck

### DIFF
--- a/AKS/AKSNodePoolCheck.psm1
+++ b/AKS/AKSNodePoolCheck.psm1
@@ -25,6 +25,14 @@ class AKSNodePoolCheck: ResourceCheck {
         return $this.NodePoolObject.count
     }
 
+    [string] getVMSize() {
+        return $this.NodePoolObject.vmSize
+    }
+
+    [string] getMode() {
+        return $this.NodePoolObject.mode
+    }
+
     [bool] hasAutoscalingEnabled() {
         return $this.NodePoolObject.enableAutoScaling
     }
@@ -40,6 +48,13 @@ class AKSNodePoolCheck: ResourceCheck {
         return $this.NodePoolObject.minCount -ge 3
     }
 
+    [bool] hasPublicIPEnabled() {
+        return $this.NodePoolObject.enableNodePublicIp
+    }
+
+    [bool] hasEphemeralOSDiskEnabled() {
+        return $this.NodePoolObject.osDiskType -eq "Ephemeral"
+    }
 
     [CheckResults] assess() {
         $rules = Get-Content AKS/aksNodePoolRules.json | ConvertFrom-Json
@@ -47,6 +62,8 @@ class AKSNodePoolCheck: ResourceCheck {
         $this.Results.Add("Cluster Name", $this.getClusterName())
         $this.Results.Add("Node Pool Name", $this.getNodePoolName())
         $this.Results.Add("Node Count", $this.getNodeCount())
+        $this.Results.Add("VM Size", $this.getVMSize())
+        $this.Results.Add("Mode", $this.getMode())
 
         foreach ($ruleTuple in $rules.PSObject.Properties) {
             $this.Results.Add($ruleTuple.Name, $this.checkRule($ruleTuple.Name, $ruleTuple.Value))

--- a/AKS/AKSNodePoolCheck.psm1
+++ b/AKS/AKSNodePoolCheck.psm1
@@ -1,0 +1,58 @@
+using module ../ResourceCheck.psm1
+using module ../CheckResults.psm1
+
+
+class AKSNodePoolCheck: ResourceCheck {
+    
+    [object]$NodePoolObject
+    [string]$ClusterName
+
+
+    AKSNodePoolCheck([string] $subscriptionId, [string] $subscriptionName, [string] $clusterName, [object] $nodePool): base($subscriptionId, $subscriptionName) {
+        $this.NodePoolObject = $nodePool
+        $this.ClusterName = $clusterName
+    }
+
+    [string] getClusterName() {
+        return $this.ClusterName
+    }
+
+    [string] getNodePoolName() {
+        return $this.NodePoolObject.name
+    }
+
+    [string] getNodeCount() {
+        return $this.NodePoolObject.count
+    }
+
+    [bool] hasAutoscalingEnabled() {
+        return $this.NodePoolObject.enableAutoScaling
+    }
+
+    [bool] hasAvailabilityZonesEnabled() {
+        if ([string]::IsNullOrEmpty($this.NodePoolObject.availabilityZones)) {
+            return $false
+        }
+        return $this.NodePoolObject.availabilityZones.Length -gt 1    
+    }
+
+    [bool] hasMin3Nodes() {
+        return $this.NodePoolObject.minCount -ge 3
+    }
+
+
+    [CheckResults] assess() {
+        $rules = Get-Content AKS/aksNodePoolRules.json | ConvertFrom-Json
+
+        $this.Results.Add("Cluster Name", $this.getClusterName())
+        $this.Results.Add("Node Pool Name", $this.getNodePoolName())
+        $this.Results.Add("Node Count", $this.getNodeCount())
+
+        foreach ($ruleTuple in $rules.PSObject.Properties) {
+            $this.Results.Add($ruleTuple.Name, $this.checkRule($ruleTuple.Name, $ruleTuple.Value))
+        }
+
+        return $this.Results
+    }
+
+}

--- a/AKS/StartAKSAssessment.ps1
+++ b/AKS/StartAKSAssessment.ps1
@@ -19,5 +19,16 @@ foreach ($currentSubscription in $subscriptions) {
 
         $aksCluster.assess().GetAllResults() | Export-Csv -Path "$OutPath\aks_assess_$today.csv" -NoTypeInformation -Append -Delimiter $csvDelimiter
         Write-Host ""
+
+        $jsonAksNodePools = az aks nodepool list --cluster-name $currentAKSCluster.name -g $currentAKSCluster.resourceGroup -o json --only-show-errors
+        $aksNodePools = $jsonAksNodePools | ConvertFrom-Json -AsHashTable
+
+        foreach ($currentNodePool in $aksNodePools) {
+            Write-Host "**** Assessing the Node Pool $($currentNodePool.name) from cluster $($currentAKSCluster.name)" -ForegroundColor Blue
+            $aksNodePool = [AKSNodePoolCheck]::new($currentSubscription.id, $currentSubscription.displayName, $currentAKSCluster.name, $currentNodePool)
+
+            $aksNodePool.assess().GetAllResults() | Export-Csv -Path "$OutPath\aks_nodepool_assess_$today.csv" -NoTypeInformation -Append -Delimiter $csvDelimiter
+            Write-Host ""
+        }
     }
 }

--- a/AKS/aksNodePoolRules.json
+++ b/AKS/aksNodePoolRules.json
@@ -1,17 +1,27 @@
 {
-  "AKS_Resiliency_Autoscaling": {
+  "AKS_NodePool_Resiliency_Autoscaling": {
     "expected": true,
     "explanation": "Autoscaling should be enabled for the nodepool. For more information, see https://learn.microsoft.com/en-us/azure/aks/cluster-autoscaler",
     "function": "hasAutoscalingEnabled"
   },
-  "AKS_Resiliency_AvailabilityZones": {
+  "AKS_NodePool_Resiliency_AvailabilityZones": {
     "expected": true,
     "explanation": "Availability zones should be enabled for the Node Pools. For more information, see https://learn.microsoft.com/en-us/azure/aks/availability-zones",
     "function": "hasAvailabilityZonesEnabled"
   },
-  "AKS_Resiliency_MinNodesPerPool": {
+  "AKS_NodePool_Resiliency_MinNodesPerPool": {
     "expected": true,
     "explanation": "For high availability, the minimum amount of nodes per pool should be 3.",
     "function": "hasMin3Nodes"
+  },
+  "AKS_NodePool_Resiliency_EphemeralOSDisk": {
+    "expected": true,
+    "explanation": "Ephemeral OS disk should be used for the nodes.",
+    "function": "hasEphemeralOSDiskEnabled"
+  },
+  "AKS_NodePool_Private_PublicIPDisabled": {
+    "expected": false,
+    "explanation": "Public IP should be disabled for the nodes in the nodepool. For more information, see https://learn.microsoft.com/en-us/azure/aks/use-node-public-ips",
+    "function": "hasPublicIPEnabled"
   }
 }

--- a/AKS/aksNodePoolRules.json
+++ b/AKS/aksNodePoolRules.json
@@ -1,0 +1,17 @@
+{
+  "AKS_Resiliency_Autoscaling": {
+    "expected": true,
+    "explanation": "Autoscaling should be enabled for the nodepool. For more information, see https://learn.microsoft.com/en-us/azure/aks/cluster-autoscaler",
+    "function": "hasAutoscalingEnabled"
+  },
+  "AKS_Resiliency_AvailabilityZones": {
+    "expected": true,
+    "explanation": "Availability zones should be enabled for the Node Pools. For more information, see https://learn.microsoft.com/en-us/azure/aks/availability-zones",
+    "function": "hasAvailabilityZonesEnabled"
+  },
+  "AKS_Resiliency_MinNodesPerPool": {
+    "expected": true,
+    "explanation": "For high availability, the minimum amount of nodes per pool should be 3.",
+    "function": "hasMin3Nodes"
+  }
+}

--- a/StartAssessment.ps1
+++ b/StartAssessment.ps1
@@ -1,4 +1,5 @@
 using module ./AKS/AKSClusterCheck.psm1
+using module ./AKS/AKSNodePoolCheck.psm1
 using module ./APIM/APIMCheck.psm1
 
 


### PR DESCRIPTION
This pull request includes changes to the Azure Kubernetes Service (AKS) assessment scripts, adding a new feature to assess node pools in AKS clusters. The most important changes are the creation of a new `AKSNodePoolCheck` class, the addition of node pool assessment in the main script, the definition of rules for node pool assessment, and the inclusion of the new module in the `StartAssessment.ps1` script.

New features:

* [`AKS/AKSNodePoolCheck.psm1`](diffhunk://#diff-fc15ccd2f634c7319ea76f35793a7fa5d9fd7d971708c3ad3144b87d3ca2b2acR1-R75): Created a new `AKSNodePoolCheck` class that extends the `ResourceCheck` class. This class has properties to store node pool data and methods to retrieve this data and assess the node pool based on a set of rules.

Enhancements to existing features:

* [`AKS/StartAKSAssessment.ps1`](diffhunk://#diff-5af5cf911b5ddd0f7c675307e83fa45e27593d49d81dd5d8c36647801c342b22R22-R32): Added code to retrieve the list of node pools in each AKS cluster and assess each node pool using the new `AKSNodePoolCheck` class. The results are exported to a CSV file.

New rules:

* [`AKS/aksNodePoolRules.json`](diffhunk://#diff-f1536c14e5e36e35125f897f580a5df6208dbe7ce7577462d2ddfd8781801221R1-R27): Defined rules for node pool assessment. Each rule has an expected value, an explanation, and the name of a function in the `AKSNodePoolCheck` class that checks the rule.

Codebase changes:

* [`StartAssessment.ps1`](diffhunk://#diff-7432688c44000f2359f5c55be00eca5b3371f96ef678f3a070538e2828d80742R2): Imported the new `AKSNodePoolCheck.psm1` module to use the `AKSNodePoolCheck` class in the main script.