### PR TITLE
Updated doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,14 @@ level agreements guaranteed by the hosted applications in the future.
 
 ### Permissions
 
-In order to complete the assessment, the user must have at least Reader
-permission/role over the Azure Kubernetes Service resources
+In order to complete the assessment, the user/service principal should be
+`Reader` on the subscriptions that you want to assess.
 
 ### Execution
 
-Login to the Azure CLI and execute the script
-
 ```powershell
-az login # -t [tenant id] (optional)
-
 # Optionally specify the output path and the CSV Delimiter as argument
-.\StartAKSClusterAssessment.ps1 #-OutPath "C:\MyPath" -csvDelimiter ","
-
+.\StartAssessment.ps1 #-OutPath "C:\MyPath" -csvDelimiter ","
 ```
 
 ### Parameters
@@ -90,12 +85,13 @@ az login # -t [tenant id] (optional)
 | ClientId     | Only if AuthType is `sp` |                  | The client ID for service principal authentication. Required if AuthType is `sp`                                                                                                                                                                                                    |
 | ClientSecret | Only if AuthType is `sp` |                  | The client secret for service principal authentication.                                                                                                                                                                                                                             |
 | TenantId     | Only if AuthType is `sp` |                  | The tenant ID for service principal authentication.                                                                                                                                                                                                                                 |
+| Services     | No                       | `all`            | A comma-separated list of services to check. Currently supported services are:<br> • `aks`<br> • `apim`                                                                                                                                                                             |
 
 ### Output
 
-An output folder named `AKS_Assessment_YYYY-MM-DD_HH-mm-ss` will be created for
-each assessment execution. The folder will contain the following files:
+An output folder named `Assessment_YYYY-MM-DD_HH-mm-ss` will be created for each
+assessment execution. The folder will contain the following files:
 
-- `assess_YYYY-MM-DD_HH-mm-ss.csv` - CSV Results of the assessment
+- `<SERVICE>_assess_YYYY-MM-DD_HH-mm-ss.csv` - CSV Results of the assessment
+- `<SERVICE>_raw_YYYY-MM-DD_HH-mm-ss.json` - Raw JSON of the analyzed resources
 - `log_YYYY-MM-DD_HH-mm-ss.txt` - Transcript of the PowerShell execution
-- `raw_YYYY-MM-DD_HH-mm-ss.json` - Raw JSON of the analyzed clusters


### PR DESCRIPTION
This pull request includes changes to the `README.md` file that clarify the execution instructions and update the output details for the assessment execution. The most important changes include updating the permissions required for the assessment, changing the execution script, and modifying the output details.

Permissions and Execution:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R75): Updated the permissions needed to complete the assessment. The user or service principal now needs to be a `Reader` on the subscriptions that are to be assessed, instead of having at least Reader permission/role over the Azure Kubernetes Service resources.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R75): The execution script has been changed from `.\StartAKSClusterAssessment.ps1` to `.\StartAssessment.ps1`. The Azure CLI login command has also been removed.

Output details:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R88-L101): The output folder and file names have been updated. The folder will now be named `Assessment_YYYY-MM-DD_HH-mm-ss` and the files will be prefixed with the service name. Additionally, a new output file in JSON format containing the raw data of the analyzed resources has been added.