### PR TITLE
feat: Fix case sensitivity issue in StartAssessment.ps1

### DIFF
--- a/StartAssessment.ps1
+++ b/StartAssessment.ps1
@@ -69,7 +69,7 @@ else {
 
 
 foreach ($svc in $servicesList) {
-    if ($allSupportedServices -contains $svc) {
+    if ($allSupportedServices -contains $svc.ToLower()) {
         $svcUpper = $svc.ToUpper()
         . "./$svcUpper/Start${svcUpper}Assessment.ps1"
     }


### PR DESCRIPTION
This pull request includes a change to the `StartAssessment.ps1` script to ensure case-insensitivity when checking if a service is in the supported services list. The service name (`$svc`) is now converted to lowercase before the check is performed. 

Here's the key change:

* [`StartAssessment.ps1`](diffhunk://#diff-7432688c44000f2359f5c55be00eca5b3371f96ef678f3a070538e2828d80742L72-R72): Modified the if-statement in the foreach loop to convert the service name to lowercase before checking if it is in the list of all supported services. This ensures that the check is case-insensitive and prevents potential issues if the service name is not in the expected case.