### PR TITLE
Added maintenance windows check

### DIFF
--- a/AKS/AKSClusterCheck.psm1
+++ b/AKS/AKSClusterCheck.psm1
@@ -241,6 +241,11 @@ class AKSClusterCheck: ResourceCheck {
         return $false
     }
 
+    [bool] hasMaintenanceWindows() {
+        $windows = az aks maintenanceconfiguration list --resource-group $this.getClusterResourceGroup() --cluster-name $this.getClusterName() -o json | ConvertFrom-Json
+        return $windows.Length -gt 0
+    }
+
 
     [string] toString() {
         return ""

--- a/AKS/aksRules.json
+++ b/AKS/aksRules.json
@@ -83,6 +83,11 @@
     "explanation": "Auto-upgrade should be enabled in the cluster. For more information, see https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-cluster",
     "function": "hasAutoUpgradeProfile"
   },
+  "AKS_Compliance_MaintenanceWindows": {
+    "expected": true,
+    "explanation": "Maintenance windows should be configured in the cluster. For more information, see https://learn.microsoft.com/en-us/azure/aks/planned-maintenance",
+    "function": "hasMaintenanceWindows"
+  },
   "AKS_Compliance_SLA": {
     "expected": true,
     "explanation": "The cluster should have a service level agreement (SLA). For more information, see https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers",


### PR DESCRIPTION
This pull request primarily focuses on implementing maintenance windows checks for AKS clusters. The changes include the addition of a new function `hasMaintenanceWindows()` in the `AKSClusterCheck` class, and a new compliance rule `AKS_Compliance_MaintenanceWindows` in `aksRules.json`.

* [`AKS/AKSClusterCheck.psm1`](diffhunk://#diff-11469093a0afc57c0a367daa3bfeb77ae3ae4982af501331c6fb5eeb5d43048aR244-R248): A new function `hasMaintenanceWindows()` was added to the `AKSClusterCheck` class. This function checks if there are any maintenance windows configured for the AKS cluster and returns a boolean value accordingly.
* [`AKS/aksRules.json`](diffhunk://#diff-86a081506d25c7f1c898738b3f5323f4fc6e97baeeb9f04fc4da0dbe70dce513R86-R90): A new compliance rule `AKS_Compliance_MaintenanceWindows` was added. This rule expects maintenance windows to be configured for the AKS cluster and uses the newly added `hasMaintenanceWindows()` function for its check.